### PR TITLE
Feat: 캘린더 CSS 수정 & 날짜별 수입/지출 데이터 동기화

### DIFF
--- a/db/db.json
+++ b/db/db.json
@@ -125,6 +125,15 @@
       "desc": "메모4",
       "amount": "530000",
       "date": "2024-06-30"
+    },
+    {
+      "id": 15,
+      "type": "income",
+      "IncomeCategory": "etc",
+      "title": "6월 수입",
+      "desc": "메모5",
+      "amount": "930000",
+      "date": "2024-06-30"
     }
   ]
 }

--- a/db/db.json
+++ b/db/db.json
@@ -11,8 +11,8 @@
     },
     {
       "id": 2,
-      "type": "expense",
-      "expenseCategory": "pin",
+      "type": "income",
+      "incomeCategory": "pin",
       "title": "5월 수입2",
       "desc": "메모2",
       "amount": "2500000",
@@ -74,8 +74,8 @@
     },
     {
       "id": 9,
-      "type": "expense",
-      "expenseCategory": "pin",
+      "type": "income",
+      "incomeCategory": "pin",
       "title": "6월 수입2",
       "desc": "메모2",
       "amount": "3000000",

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -19,12 +19,12 @@ import dayGridPlugin from '@fullcalendar/daygrid'
 import interactionPlugin from '@fullcalendar/interaction'
 
 import { reactive, computed, watch } from 'vue'
-import { useAccountListStore } from '@/stores/account.js'
+import { useCalendarAccountStore } from '@/stores/calendarAccount'
 
-const accountListStore = useAccountListStore();
-const accountList = computed(() => accountListStore.accountList); //읽기 전용 반응형 ref 객체 반환
+const calendarAccountStore = useCalendarAccountStore();
+const summaryList = computed(() => calendarAccountStore.summaryList); //읽기 전용 반응형 ref 객체 반환
 
-const { fetchAccountList } = accountListStore;
+const { fetchSummaryList } = calendarAccountStore;
 
 const state = reactive({
   calendarOptions: {
@@ -40,11 +40,11 @@ const state = reactive({
   },
 })
 
-fetchAccountList();
+fetchSummaryList();
 
 //수입,지출목록 변경 시 캘린더 이벤트 업데이트
-watch(accountList, (newAccountList) => {
-  state.calendarOptions.events = newAccountList;
+watch(summaryList, (newSummaryList) => {
+  state.calendarOptions.events = newSummaryList;
 });
 
 </script>

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -69,4 +69,52 @@ watch(summaryList, (newSummaryList) => {
   background-color:#4A483F;
   color:white
 }
+
+/* 이벤트 배경색 제거 */
+.fc-h-event {
+  background-color:rgba(255, 255, 255, 0);
+  border:1px solid rgba(51, 45, 45, 0);
+}
+
+/* 총수입 폰트색 */
+.fc .income-event .fc-event-title  {
+  color:#35948C !important;
+}
+/* 총지출 폰트색 */
+.fc .expense-event .fc-event-title {
+  color:#CF5A7A !important;
+}
+
+.fc-event-title {
+  font-weight:2.5rem;
+}
+
+/* 이벤트 날짜 아래로 분리 */
+.fc-daygrid-day-frame {
+  flex-direction: column;
+}
+/* 금액 오른쪽 정렬 */
+.fc-daygrid-day-events {
+  margin-left:auto;
+}
+
+.fc-daygrid-day-events {
+  flex-direction: column;
+}
+
+/* 요일,날짜 폰트 CSS 수정 */
+.fc-col-header-cell-cushion, .fc-daygrid-day-number {
+  color:black;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+/* 캘린더 헤더 배경 & 폰트 색 수정 */
+.fc-col-header {
+  background-color:#6E6053;
+}
+.fc-col-header-cell-cushion {
+  color:white;
+}
+
 </style>

--- a/src/pages/Calendar.vue
+++ b/src/pages/Calendar.vue
@@ -94,7 +94,7 @@ watch(summaryList, (newSummaryList) => {
   flex-direction: column;
 }
 /* 금액 오른쪽 정렬 */
-.fc-daygrid-day-events {
+.fc-daygrid-day-events, .fc-daygrid-event-harness {
   margin-left:auto;
 }
 

--- a/src/stores/calendarAccount.js
+++ b/src/stores/calendarAccount.js
@@ -1,6 +1,7 @@
 import { ref, computed, reactive } from 'vue';
 import { defineStore } from 'pinia';
 import axios from 'axios';
+import { moneyFormat } from '@/utils/moneyFormat';
 
 export const useCalendarAccountStore = defineStore('summaryList', () => {
   const BASEURI = '/api/account';
@@ -39,7 +40,7 @@ export const useCalendarAccountStore = defineStore('summaryList', () => {
             if (income > 0) {
                 summary.push({
                     date,
-                    title: `+${income}원`,
+                    title: `+ ${moneyFormat(income)}`,
                     type: 'income',
                     className: 'income-event'
                 });
@@ -47,7 +48,7 @@ export const useCalendarAccountStore = defineStore('summaryList', () => {
             if (expense > 0) {
                 summary.push({
                     date,
-                    title: `-${expense}원`,
+                    title: `- ${moneyFormat(expense)}`,
                     type: 'expense',
                     className: 'expense-event'
                 });

--- a/src/stores/calendarAccount.js
+++ b/src/stores/calendarAccount.js
@@ -1,0 +1,69 @@
+import { ref, computed, reactive } from 'vue';
+import { defineStore } from 'pinia';
+import axios from 'axios';
+
+export const useCalendarAccountStore = defineStore('summaryList', () => {
+  const BASEURI = '/api/account';
+  const state = reactive({ summaryList: [] });
+
+  /* 
+  * 전체 캘린더 날짜별 수입/지출 요약: 리턴 - title(수입 0원//지출 0원//순수입?), date
+  */
+  const fetchSummaryList = async () => {
+    try {
+      const res = await axios.get(BASEURI);
+
+      if (res.status === 200) {
+        const accounts = res.data;
+        
+        const summaryMap = {}; // 총수입/총지출 맵
+
+        // 날짜별로 그룹화하여 총수입과 총지출을 계산
+        accounts.forEach(account => {
+          const date = account.date;
+          if (!summaryMap[date]) {
+            summaryMap[date] = { income: 0, expense: 0 };
+          }
+
+          if (account.type === 'income') {
+            summaryMap[date].income += parseFloat(account.amount);
+          } else if (account.type === 'expense') {
+            summaryMap[date].expense += parseFloat(account.amount);
+          }
+        });
+
+
+        // summary -> state.summaryList에 저장
+        let summary = [];
+        state.summaryList = Object.entries(summaryMap).map(([date, { income, expense }]) => {
+            if (income > 0) {
+                summary.push({
+                    date,
+                    title: `총수입: ${income}원`,
+                    type: 'income'
+                });
+            }
+            if (expense > 0) {
+                summary.push({
+                    date,
+                    title: `총지출: ${expense}원`,
+                    type: 'expense'
+                });
+            }
+        });    
+        state.summaryList = summary;
+
+      } else {
+        alert('Failed');
+      }
+
+    } catch (err) {
+      alert('ERROR: ' + err);
+    }
+  };
+
+  const summaryList = computed(() => state.summaryList);
+  const isLoading = computed(() => state.isLoading);
+
+  return { summaryList, isLoading, fetchSummaryList };
+});

--- a/src/stores/calendarAccount.js
+++ b/src/stores/calendarAccount.js
@@ -39,15 +39,17 @@ export const useCalendarAccountStore = defineStore('summaryList', () => {
             if (income > 0) {
                 summary.push({
                     date,
-                    title: `총수입: ${income}원`,
-                    type: 'income'
+                    title: `+${income}원`,
+                    type: 'income',
+                    className: 'income-event'
                 });
             }
             if (expense > 0) {
                 summary.push({
                     date,
-                    title: `총지출: ${expense}원`,
-                    type: 'expense'
+                    title: `-${expense}원`,
+                    type: 'expense',
+                    className: 'expense-event'
                 });
             }
         });    

--- a/src/utils/moneyFormat.js
+++ b/src/utils/moneyFormat.js
@@ -1,0 +1,10 @@
+/*
+* 금액 ₩999,999,999 표시 포맷 함수
+*/
+export const moneyFormat = (amount) => {
+    return new Intl.NumberFormat('ko-KR', {
+      style: 'currency',
+      currency: 'KRW',
+      minimumFractionDigits: 0
+    }).format(amount);
+};


### PR DESCRIPTION
## ⚒️ 작업 사항
> 주요 작업 사항 목록 입력 (이미지 첨부 가능)

- 캘린더 날짜별 총수입/총지출 데이터 동기화 
- 캘린더 전체적인 CSS 수정: 수입/지출 색 구분 적용
- 금액 포맷 설정 유틸 함수 추가: 캘린더에 적용

### 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
